### PR TITLE
Clean exceptions

### DIFF
--- a/circus/core/__init__.py
+++ b/circus/core/__init__.py
@@ -30,7 +30,7 @@ from circus.core.circus_exceptions import DuplicateRegItemError, \
     MismatchRegMetaKeysError
 
 logging.basicConfig(datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG,
-                    format=('> %(asctime)s %(funcName)s:%(lineno)d\n  ' +
+                    format=('\n> %(asctime)s %(funcName)s:%(lineno)d\n  ' +
                             logging.BASIC_FORMAT))
 LOGGER = logging.getLogger(__name__)
 

--- a/circus/core/__init__.py
+++ b/circus/core/__init__.py
@@ -30,7 +30,7 @@ from circus.core.circus_exceptions import DuplicateRegItemError, \
     MismatchRegMetaKeysError
 
 logging.basicConfig(datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG,
-                    format=('> %(asctime)s %(funcName)s:%(lineno)d\n> ' +
+                    format=('> %(asctime)s %(funcName)s:%(lineno)d\n  ' +
                             logging.BASIC_FORMAT))
 LOGGER = logging.getLogger(__name__)
 

--- a/circus/core/circus_exceptions.py
+++ b/circus/core/circus_exceptions.py
@@ -6,9 +6,10 @@ Exceptions for Circus.
 
 class CircusException(Exception):
     """
-    Base exception class for pvmismatch.
+    Base exception class for Circus.
     """
-    pass
+    def __str__(self):
+        return self.message
 
 
 class UnnamedDataError(CircusException):
@@ -19,12 +20,8 @@ class UnnamedDataError(CircusException):
     :type filename: str
     """
     def __init__(self, filename):
-        self.args = filename
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = 'Data read from %s without names.' % self.args
-        return error_message
+        self.filename = filename
+        self.message = 'Data read from "%s" without names.' % self.filename
 
 
 class PVSimTimezoneError(CircusException):
@@ -35,12 +32,8 @@ class PVSimTimezoneError(CircusException):
     :type timezone: str
     """
     def __init__(self, timezone):
-        self.args = timezone
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = 'Incorrect timezone format: "%s".' % self.args
-        return error_message
+        self.timezone = timezone
+        self.message = 'Incorrect timezone format: "%s".' % self.timezone
 
 
 class DuplicateRegItemError(CircusException):
@@ -51,13 +44,9 @@ class DuplicateRegItemError(CircusException):
     :type keys: set
     """
     def __init__(self, keys):
-        self.args = keys
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Duplicate data can\'t be registered:',
-                        '\n\t"%s".' % ', '.join(self.args)]
-        return '\n'.join(error_message)
+        self.duplicate_keys = keys
+        self.message = ('Duplicate data can\'t be registered:\n\t%s' %
+                        '\n\t'.join(self.duplicate_keys))
 
 
 class MismatchRegMetaKeysError(CircusException):
@@ -68,13 +57,9 @@ class MismatchRegMetaKeysError(CircusException):
     :type keys: set
     """
     def __init__(self, keys):
-        self.args = keys
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Meta must be a subset of registry:',
-                        '\n\t"%s".' % ', '.join(self.args)]
-        return '\n'.join(error_message)
+        self.mismatch_keys = keys
+        self.message = ('Meta must be a subset of registry:\n\t%s' %
+                        '\n\t'.join(self.mismatch_keys))
 
 
 class UncertaintyPercentUnitsError(CircusException):
@@ -87,13 +72,12 @@ class UncertaintyPercentUnitsError(CircusException):
     :type units: str
     """
     def __init__(self, key, units):
-        self.args = key, units
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Uncertainty can only have units of percent (%%),',
-                        'but "%s" has units of "%s" instead.' % self.args]
-        return ' '.join(error_message)
+        self.data_key = key
+        self.units = units
+        self.message = (
+            'Uncertainty can only have units of percent (%%), but "%s" ' +
+            'has units of "%s" instead.'
+        ) % (self.data_key, self.units)
 
 
 class UncertaintyBoundsUnitsError(CircusException):
@@ -110,14 +94,14 @@ class UncertaintyBoundsUnitsError(CircusException):
     :type up_units: :mod:`quantities`
     """
     def __init__(self, key, lo_units, up_units):
-        self.args = key, lo_units.dimensionality, up_units.dimensionality
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Uncertainty lower and upper bounds must both have',
-                         'units of percent (%%), but "%s" has units of "%s"',
-                         'for the lower bound and "%s" for the upper bound.']
-        return ' '.join(error_message) % self.args
+        self.data_key = key
+        self.lo_units = lo_units.dimensionality
+        self.up_units = up_units.dimensionality
+        self.message = (
+            'Uncertainty lower and upper bounds must both have units of ' +
+            'percent (%%), but "%s" has units of "%s" for the lower bound ' +
+            'and "%s" for the upper bound.'
+        ) % (self.data_key, self.lo_units, self.up_units)
 
 
 class CircularDependencyError(Exception):
@@ -125,11 +109,8 @@ class CircularDependencyError(Exception):
     Topological sort cyclic error.
     """
     def __init__(self, keys):
-        self.args = keys
-        self.message = self.__str__
-
-    def __str__(self):
-        return 'Not a DAG. These keys are cyclic:\n\t%s' % str(self.args)
+        self.calc = keys
+        self.message = 'Not a DAG. Cyclic keys:\n\t%s' % '\n\t'.join(self.calc)
 
 
 class MixedTextNoMatchError(Exception):
@@ -137,8 +118,8 @@ class MixedTextNoMatchError(Exception):
     No match in mixed text data source error.
     """
     def __init__(self, re_meth, pattern, data):
-        self.args = re_meth, pattern, data
-        self.message = self.__str__
-
-    def __str__(self):
-        return 'No match using regex "%s" with "%s" in "%s".' % self.args
+        self.re_meth = re_meth
+        self.pattern = pattern
+        self.data = data
+        self.message = ('No match using regex "%s" with "%s" in "%s".' %
+                        (self.re_meth, self.pattern, self.data))

--- a/circus/tests/test_circus_exceptions.py
+++ b/circus/tests/test_circus_exceptions.py
@@ -1,0 +1,55 @@
+"""
+test circus exceptions
+"""
+
+from circus.core import logging
+from circus.core.circus_exceptions import (
+    UnnamedDataError, PVSimTimezoneError, DuplicateRegItemError
+)
+from nose.tools import raises, eq_
+
+LOGGER = logging.getLogger(__name__)
+
+
+@raises(UnnamedDataError)
+def test_unnamed_data_error():
+    filename = 'myfile.test'
+    try:
+        raise UnnamedDataError(filename)
+    except UnnamedDataError as err:
+        LOGGER.debug('error: %s', err.__class__)
+        eq_(err.filename, filename)
+        LOGGER.debug('filename: %s', err.filename)
+        eq_(err.message, 'Data read from "%s" without names.' % filename)
+        LOGGER.debug('message: %s', err.message)
+        raise err
+
+
+@raises(PVSimTimezoneError)
+def test_timezone_error():
+    timezone = 'US/Pacific'
+    try:
+        raise PVSimTimezoneError(timezone)
+    except PVSimTimezoneError as err:
+        LOGGER.debug('error: %s', err.__class__)
+        eq_(err.timezone, timezone)
+        LOGGER.debug('timezone: %s', err.timezone)
+        eq_(err.message, 'Incorrect timezone format: "%s".' % timezone)
+        LOGGER.debug('message: %s', err.message)
+        raise err
+
+
+@raises(DuplicateRegItemError)
+def test_duplicate_registry_item_error():
+    duplicate_keys = {'foo', 'bar'}
+    try:
+        raise DuplicateRegItemError(duplicate_keys)
+    except DuplicateRegItemError as err:
+        LOGGER.debug('error: %s', err.__class__)
+        eq_(err.duplicate_keys, duplicate_keys)
+        LOGGER.debug('duplicate_keys: %s', err.duplicate_keys)
+        eq_(err.message,
+            "Duplicate data can't be registered:\n\t%s" %
+            '\n\t'.join(duplicate_keys))
+        LOGGER.debug('message: %s', err.message)
+        raise err

--- a/examples/PVPower/formulas/irradiance.json
+++ b/examples/PVPower/formulas/irradiance.json
@@ -1,0 +1,14 @@
+{
+  "module": "irradiance",
+  "package": null,
+  "path": null,
+  "formulas": {
+    "f_clearsky": {"islinear": true},
+    "f_solpos": {"islinear": true},
+    "f_dni_extra": {"islinear": true},
+    "f_airmass": {"islinear": true},
+    "f_pressure": {"islinear": true},
+    "f_am_abs": {"islinear": true},
+    "f_total_irrad": {"islinear": true}
+  }
+}

--- a/examples/PVPower/formulas/performance.json
+++ b/examples/PVPower/formulas/performance.json
@@ -1,0 +1,11 @@
+{
+  "module": "performance",
+  "package": null,
+  "path": null,
+  "formulas": {
+    "f_ac_power": {"islinear": true},
+    "f_dc_power": {"islinear": true},
+    "f_cell_temp": {"islinear": true},
+    "f_aoi": {"islinear": true}
+  }
+}

--- a/examples/PVPower/formulas/pvpower.json
+++ b/examples/PVPower/formulas/pvpower.json
@@ -1,10 +1,10 @@
 {
-    "module": "pvpower",
-    "package": null,
-    "path": null,
-    "formulas": {
-        "f_daterange": {"islinear": true},
-        "f_energy": {"islinear": true},
-        "f_rollup": {"islinear": true}
-    }
+  "module": "pvpower",
+  "package": null,
+  "path": null,
+  "formulas": {
+    "f_daterange": {"islinear": true},
+    "f_energy": {"islinear": true},
+    "f_rollup": {"islinear": true}
+  }
 }

--- a/examples/PVPower/models/default.json
+++ b/examples/PVPower/models/default.json
@@ -1,12 +1,38 @@
 {
   "outputs": {
-    "pvpower": {
+    "PVPowerOutputs": {
       "module": ".outputs",
       "package": "pvpower"
     }
   },
-  "formulas": null, 
+  "formulas": {
+    "PVPowerFormulas": {
+      "module": ".formulas",
+      "package": "pvpower"
+    },
+    "PerformanceFormulas": {
+      "module": ".formulas",
+      "package": "pvpower"
+    },
+    "IrradianceFormulas": {
+      "module": ".formulas",
+      "package": "pvpower"
+    }
+  },
   "data": null, 
-  "calculations": null, 
+  "calculations": {
+    "PVPowerCalcs": {
+      "module": ".calculations",
+      "package": "pvpower"
+    },
+    "PerformanceCalcs": {
+      "module": ".calculations",
+      "package": "pvpower"
+    },
+    "IrradianceCalcs": {
+      "module": ".calculations",
+      "package": "pvpower"
+    }
+  },
   "simulations": null
 }

--- a/examples/PVPower/pvpower/__init__.py
+++ b/examples/PVPower/pvpower/__init__.py
@@ -1,5 +1,5 @@
 """
-This is the pvpower package.
+This is the PVPower Circus Demonstration Model.
 """
 
 import os

--- a/examples/PVPower/pvpower/calculations.py
+++ b/examples/PVPower/pvpower/calculations.py
@@ -6,17 +6,19 @@ from circus.core.calculations import Calc
 import os
 from pvpower import PROJ_PATH
 
+CALC_PATH = os.path.join(PROJ_PATH, 'calculations')
+
 
 class PVPowerCalcs(Calc):
-    outputs_file = 'pvpower.json'
-    outputs_path = os.path.join(PROJ_PATH, 'calculations')
+    calcs_file = 'pvpower.json'
+    calcs_path = CALC_PATH
 
 
-class PVerformanceCalcs(Calc):
-    outputs_file = 'performance.json'
-    outputs_path = os.path.join(PROJ_PATH, 'calculations')
+class PerformanceCalcs(Calc):
+    calcs_file = 'performance.json'
+    calcs_path = CALC_PATH
 
 
 class IrradianceCalcs(Calc):
-    outputs_file = 'irradiance.json'
-    outputs_path = os.path.join(PROJ_PATH, 'calculations')
+    calcs_file = 'irradiance.json'
+    calcs_path = CALC_PATH

--- a/examples/PVPower/pvpower/formulas.py
+++ b/examples/PVPower/pvpower/formulas.py
@@ -1,0 +1,23 @@
+"""
+Formulas for PV Power demo
+"""
+
+from circus.core.formulas import Formula
+import os
+from pvpower import PROJ_PATH
+
+FORMULA_PATH = os.path.join(PROJ_PATH, 'formulas')
+
+class PVPowerFormulas(Formula):
+    formulas_file = 'pvpower.json'
+    formulas_path = FORMULA_PATH
+
+
+class PerformanceFormulas(Formula):
+    formulas_file = 'performance.json'
+    formulas_path = FORMULA_PATH
+
+
+class IrradianceFormulas(Formula):
+    formulas_file = 'irradiance.json'
+    formulas_path = FORMULA_PATH

--- a/examples/PVPower/tests/test_pvpower.py
+++ b/examples/PVPower/tests/test_pvpower.py
@@ -5,41 +5,39 @@ Tests for pvpower formulas
 from datetime import datetime, timedelta
 import numpy as np
 import pytz
-from time import clock
-import logging
 # XXX: add circus to python path for testing!
-from circus.core import UREG
+from circus.core import UREG, logging
 # XXX: add pvpower to python path for testing!
 from pvpower.formulas import PVPowerFormulas
 
-logging.basicConfig()
 LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(logging.DEBUG)
 PST = pytz.timezone('US/Pacific')
 FORMULAS = PVPowerFormulas()
-
-
+DTSTART = PST.localize(datetime(2007, 1, 1, 0, 0, 0))
 MONTHLY_ENERGY = [186000.0, 168000.0, 186000.0, 180000.0, 186000.0, 180000.0,
                   186000.0, 186000.0, 180000.0, 186000.0, 180000.0, 186000.0]
+
+
+def test_daterange():
+    """
+    test date range
+    """
+    dates = FORMULAS['f_daterange']('HOURLY', dtstart=DTSTART, count=12)
+    for hour in xrange(12):
+        assert dates[hour] == DTSTART + timedelta(hours=hour)
 
 
 def test_rollup():
     """
     test rollup
     """
-    dtstart = PST.localize(datetime(2007, 1, 1, 0, 0, 0))
-    dates = FORMULAS['f_daterange']('HOURLY', dtstart=dtstart, count=8761)
-    assert dates[0] == dtstart
-    assert dates[12] == dtstart + timedelta(hours=12)
+    dates = FORMULAS['f_daterange']('HOURLY', dtstart=DTSTART, count=8761)
     ac_power = 1000. * np.sin(np.arange(12) * np.pi / 12.0) ** 2
     ac_power = np.pad(ac_power, [6, 6], 'constant')
     ac_power = np.append(np.tile(ac_power, (365,)), [0]) * UREG.watt
     energy, energy_times = FORMULAS['f_energy'](ac_power, dates)
     assert energy.units == UREG.Wh
-    start = clock()
     monthly_energy = FORMULAS['f_rollup'](energy, energy_times, 'MONTHLY')
-    stop = clock()
-    LOGGER.debug('elapsed time: %g [ms]', (stop - start) * 1000.)
     assert np.allclose(monthly_energy[:12], MONTHLY_ENERGY)
     return dates, ac_power, energy, energy_times, monthly_energy
 

--- a/examples/PVPower/tests/test_pvpower.py
+++ b/examples/PVPower/tests/test_pvpower.py
@@ -1,56 +1,48 @@
 """
-tests for pvpower formulas
+Tests for pvpower formulas
 """
 
 from datetime import datetime, timedelta
 import numpy as np
 import pytz
-import imp
-import os
 from time import clock
 import logging
+# XXX: add circus to python path for testing!
 from circus.core import UREG
+# XXX: add pvpower to python path for testing!
+from pvpower.formulas import PVPowerFormulas
 
 logging.basicConfig()
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 PST = pytz.timezone('US/Pacific')
-MODNAME = 'pvpower'
-BASEDIR = os.path.dirname(__file__)
-LOGGER.debug('base dir:\n> %s', BASEDIR)
-MODPATH = os.path.abspath(os.path.join(BASEDIR, '..', 'formulas'))
-LOGGER.debug('path:\n> %s', MODPATH)
-MODFID, MODFN, MODINFO = None, None, None
+FORMULAS = PVPowerFormulas()
 
-try:
-    MODFID, MODFN, MODINFO = imp.find_module(MODNAME,[MODPATH])
-    MOD = imp.load_module(MODNAME, MODFID, MODFN, MODINFO)
-finally:
-    if MODFID:
-        MODFID.close()
 
 MONTHLY_ENERGY = [186000.0, 168000.0, 186000.0, 180000.0, 186000.0, 180000.0,
                   186000.0, 186000.0, 180000.0, 186000.0, 180000.0, 186000.0]
+
 
 def test_rollup():
     """
     test rollup
     """
     dtstart = PST.localize(datetime(2007, 1, 1, 0, 0, 0))
-    dates = MOD.f_daterange('HOURLY', dtstart=dtstart, count=8761)
+    dates = FORMULAS['f_daterange']('HOURLY', dtstart=dtstart, count=8761)
     assert dates[0] == dtstart
     assert dates[12] == dtstart + timedelta(hours=12)
-    Pac = 1000. * np.sin(np.arange(12) * np.pi / 12.0) ** 2
-    Pac = np.pad(Pac, [6, 6], 'constant')
-    Pac = np.append(np.tile(Pac, 365), 0) * UREG.watt
-    energy, energy_times = MOD.f_energy(Pac, dates)
+    ac_power = 1000. * np.sin(np.arange(12) * np.pi / 12.0) ** 2
+    ac_power = np.pad(ac_power, [6, 6], 'constant')
+    ac_power = np.append(np.tile(ac_power, (365,)), [0]) * UREG.watt
+    energy, energy_times = FORMULAS['f_energy'](ac_power, dates)
     assert energy.units == UREG.Wh
     start = clock()
-    monthly_energy = MOD.f_rollup(energy, energy_times, 'MONTHLY')
+    monthly_energy = FORMULAS['f_rollup'](energy, energy_times, 'MONTHLY')
     stop = clock()
     LOGGER.debug('elapsed time: %g [ms]', (stop - start) * 1000.)
     assert np.allclose(monthly_energy[:12], MONTHLY_ENERGY)
+    return dates, ac_power, energy, energy_times, monthly_energy
 
 
 if __name__ == "__main__":
-    test_rollup()
+    results = test_rollup()


### PR DESCRIPTION
* exceptions should not set `args`
* make exception attributes meaningful, otherwise why keep them? _ie_: `UnnamedDataError` attribute should be `filename` so that it can be used to determine how this exception is handled.
* set the `__str__()` method once in the base circus exception class, set it to `self.message` and then just set the message in all the rest of the circus exceptions.
* make some tests to check that it's working

Note, this PR depends on #12 so please disregard those commits.
* https://github.com/mikofski/Circus/commit/2eba6113ffd04b1eb0e55dfef26dabab118de76c - add `test_daterange`
* https://github.com/mikofski/Circus/commit/8d9100d3f4622ecd8cefec1ce5c320c2fc4168dc - update `test_pvpower` to use `Formula` classes
* https://github.com/mikofski/Circus/commit/80559468f62663d60bbfd07f8c059a24e17bea00 - add formula `param_files`

cc/ @SunPowerMike, @bwiktorowicz, @zdefreitas, @anomam and @ddedrick