### PR TITLE
PV Power demo data sources

### DIFF
--- a/circus/core/__init__.py
+++ b/circus/core/__init__.py
@@ -39,6 +39,8 @@ UREG = pint.UnitRegistry()  # registry of units
 Q_ = UREG.Quantity
 UREG.define('lumen = cd * sr = lm')
 UREG.define('lux = lumen / m ** 2 = lx')
+UREG.define('fraction = []')
+UREG.define('percent = fraction / 100.0 = pct')
 
 # constants
 YEAR = 2013 * UREG.year
@@ -188,6 +190,8 @@ def convert_args(test_fcn, *test_args):
 
 # NOTE: Preferred way to compare units is with dimensionality
 # EG: (25 * UREG.degC).dimensionality == UREG.degC.dimensionality
+# XXX: Really? because this works too, seems way better!
+# EG: (25 * UREG.degC).units = UREG.degC
 
 
 def dimensionless_to_index(index):

--- a/circus/core/__init__.py
+++ b/circus/core/__init__.py
@@ -30,7 +30,7 @@ from circus.core.circus_exceptions import DuplicateRegItemError, \
     MismatchRegMetaKeysError
 
 logging.basicConfig(datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG,
-                    format=('> %(asctime)s %(funcName)s:%(lineno)d\n  ' +
+                    format=('\n> %(asctime)s %(funcName)s:%(lineno)d\n  ' +
                             logging.BASIC_FORMAT))
 LOGGER = logging.getLogger(__name__)
 

--- a/circus/core/__init__.py
+++ b/circus/core/__init__.py
@@ -30,7 +30,7 @@ from circus.core.circus_exceptions import DuplicateRegItemError, \
     MismatchRegMetaKeysError
 
 logging.basicConfig(datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG,
-                    format=('> %(asctime)s %(funcName)s:%(lineno)d\n> ' +
+                    format=('> %(asctime)s %(funcName)s:%(lineno)d\n  ' +
                             logging.BASIC_FORMAT))
 LOGGER = logging.getLogger(__name__)
 

--- a/circus/core/circus_exceptions.py
+++ b/circus/core/circus_exceptions.py
@@ -6,9 +6,10 @@ Exceptions for Circus.
 
 class CircusException(Exception):
     """
-    Base exception class for pvmismatch.
+    Base exception class for Circus.
     """
-    pass
+    def __str__(self):
+        return self.message
 
 
 class UnnamedDataError(CircusException):
@@ -19,12 +20,8 @@ class UnnamedDataError(CircusException):
     :type filename: str
     """
     def __init__(self, filename):
-        self.args = filename
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = 'Data read from %s without names.' % self.args
-        return error_message
+        self.filename = filename
+        self.message = 'Data read from "%s" without names.' % self.filename
 
 
 class PVSimTimezoneError(CircusException):
@@ -35,12 +32,8 @@ class PVSimTimezoneError(CircusException):
     :type timezone: str
     """
     def __init__(self, timezone):
-        self.args = timezone
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = 'Incorrect timezone format: "%s".' % self.args
-        return error_message
+        self.timezone = timezone
+        self.message = 'Incorrect timezone format: "%s".' % self.timezone
 
 
 class DuplicateRegItemError(CircusException):
@@ -51,13 +44,9 @@ class DuplicateRegItemError(CircusException):
     :type keys: set
     """
     def __init__(self, keys):
-        self.args = keys
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Duplicate data can\'t be registered:',
-                        '\n\t"%s".' % ', '.join(self.args)]
-        return '\n'.join(error_message)
+        self.duplicate_keys = keys
+        self.message = ('Duplicate data can\'t be registered:\n\t%s' %
+                        '\n\t'.join(self.duplicate_keys))
 
 
 class MismatchRegMetaKeysError(CircusException):
@@ -68,13 +57,9 @@ class MismatchRegMetaKeysError(CircusException):
     :type keys: set
     """
     def __init__(self, keys):
-        self.args = keys
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Meta must be a subset of registry:',
-                        '\n\t"%s".' % ', '.join(self.args)]
-        return '\n'.join(error_message)
+        self.mismatch_keys = keys
+        self.message = ('Meta must be a subset of registry:\n\t%s' %
+                        '\n\t'.join(self.mismatch_keys))
 
 
 class UncertaintyPercentUnitsError(CircusException):
@@ -87,13 +72,12 @@ class UncertaintyPercentUnitsError(CircusException):
     :type units: str
     """
     def __init__(self, key, units):
-        self.args = key, units
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Uncertainty can only have units of percent (%%),',
-                        'but "%s" has units of "%s" instead.' % self.args]
-        return ' '.join(error_message)
+        self.data_key = key
+        self.units = units
+        self.message = (
+            'Uncertainty can only have units of percent (%%), but "%s" ' +
+            'has units of "%s" instead.'
+        ) % (self.data_key, self.units)
 
 
 class UncertaintyBoundsUnitsError(CircusException):
@@ -110,14 +94,14 @@ class UncertaintyBoundsUnitsError(CircusException):
     :type up_units: :mod:`quantities`
     """
     def __init__(self, key, lo_units, up_units):
-        self.args = key, lo_units.dimensionality, up_units.dimensionality
-        self.message = str(self)
-
-    def __str__(self):
-        error_message = ['Uncertainty lower and upper bounds must both have',
-                         'units of percent (%%), but "%s" has units of "%s"',
-                         'for the lower bound and "%s" for the upper bound.']
-        return ' '.join(error_message) % self.args
+        self.data_key = key
+        self.lo_units = lo_units.dimensionality
+        self.up_units = up_units.dimensionality
+        self.message = (
+            'Uncertainty lower and upper bounds must both have units of ' +
+            'percent (%%), but "%s" has units of "%s" for the lower bound ' +
+            'and "%s" for the upper bound.'
+        ) % (self.data_key, self.lo_units, self.up_units)
 
 
 class CircularDependencyError(Exception):
@@ -125,11 +109,8 @@ class CircularDependencyError(Exception):
     Topological sort cyclic error.
     """
     def __init__(self, keys):
-        self.args = keys
-        self.message = self.__str__
-
-    def __str__(self):
-        return 'Not a DAG. These keys are cyclic:\n\t%s' % str(self.args)
+        self.calc = keys
+        self.message = 'Not a DAG. Cyclic keys:\n\t%s' % '\n\t'.join(self.calc)
 
 
 class MixedTextNoMatchError(Exception):
@@ -137,8 +118,8 @@ class MixedTextNoMatchError(Exception):
     No match in mixed text data source error.
     """
     def __init__(self, re_meth, pattern, data):
-        self.args = re_meth, pattern, data
-        self.message = self.__str__
-
-    def __str__(self):
-        return 'No match using regex "%s" with "%s" in "%s".' % self.args
+        self.re_meth = re_meth
+        self.pattern = pattern
+        self.data = data
+        self.message = ('No match using regex "%s" with "%s" in "%s".' %
+                        (self.re_meth, self.pattern, self.data))

--- a/circus/core/data_readers.py
+++ b/circus/core/data_readers.py
@@ -6,7 +6,7 @@ which are used to read in data sources.
 """
 
 from StringIO import StringIO
-from circus.core import UREG
+from circus.core import UREG, Q_
 from circus.core.circus_exceptions import UnnamedDataError, \
     MixedTextNoMatchError
 from xlrd import open_workbook
@@ -147,8 +147,14 @@ class JSON_Reader(DataReader):
         Apply units to data read using :class:`JSON_Reader`.
         """
         for k, v in parameters.iteritems():
-            data[k] *= str(v.get('units') or '')
+            units = v.get('units')
+            if units is not None:
+                data[k] = Q_(data[k], v.get('units'))
         return data
+        # data_with_units = {k: Q_(data[k], v.get('units'))
+        #                    for k, v in parameters.iteritems()
+        #                    if v.get('units') is not None}
+        # return data.update(data_with_units)
 
 
 class XLRD_Reader(DataReader):

--- a/circus/core/data_readers.py
+++ b/circus/core/data_readers.py
@@ -68,7 +68,6 @@ class JSON_Reader(DataReader):
     :type parameters: dict
     :param data_reader: Original :class:`DataReader` if data are saved in JSON
         format.
-    :type data_reader: :class:`DataReader`
 
     This the default data reader. If a data source is specified without a
     reader then an attempt will be made to read it as JSON data.
@@ -79,8 +78,12 @@ class JSON_Reader(DataReader):
     For example::
 
     {
-        "DNI": [834, 523, 334, 34, 0, 0],
-        "zenith": [21, 28, 45, 79, 90, 90]
+        "data": {
+            "DNI": [834, 523, 334, 34, 0, 0],
+            "zenith": [21, 28, 45, 79, 90, 90]
+        },
+        "param_file": "path/to/corresponding/param_file.json",
+        "data_source": "MyDataSource"
     }
 
     Units and other meta properties should be specified in a parameter file.
@@ -147,13 +150,12 @@ class JSON_Reader(DataReader):
         Apply units to data read using :class:`JSON_Reader`.
         """
         for k, v in parameters.iteritems():
-            units = v.get('units')
-            if units is not None:
+            if 'units' in v:
                 data[k] = Q_(data[k], v.get('units'))
         return data
         # data_with_units = {k: Q_(data[k], v.get('units'))
         #                    for k, v in parameters.iteritems()
-        #                    if v.get('units') is not None}
+        #                    if 'units' in v}
         # return data.update(data_with_units)
 
 

--- a/circus/core/data_sources.py
+++ b/circus/core/data_sources.py
@@ -14,21 +14,15 @@ for data sources are as follows:
     meta-data the registry requires.
 """
 
-from circus.core import UREG, YEAR, _DATA, Registry, CircusJSONEncoder
-from data_readers import XLRD_Reader, NumPyLoadTxtReader, \
-    NumPyGenFromTxtReader, Parameterized_XLS, JSON_Reader, Mixed_Text_XLS
-from circus.core.circus_exceptions import PVSimTimezoneError, \
-    UncertaintyPercentUnitsError, UncertaintyBoundsUnitsError
+from circus.core import UREG, Registry, CircusJSONEncoder, CommonBase
+from data_readers import JSON_Reader
+from circus.core.circus_exceptions import UncertaintyPercentUnitsError
 import json
-import numpy as np
-from datetime import datetime, timedelta
 import os
-import re
 import time
-import importlib
-from xlrd import xldate_as_tuple, open_workbook
+import functools
 
-DFLT_UNC = 1 * UREG['%']  # default uncertainty
+DFLT_UNC = 1.0 * UREG['percent']  # default uncertainty
 
 
 class DataRegistry(Registry):
@@ -62,29 +56,34 @@ class DataRegistry(Registry):
         # getmembers(obj, predicate) is same as dir(obj) but tuple, and
         # filtered when predicate true.
 
-    def register(self, newdata, uncertainty, isconstant, timeseries,
-                 data_source):
+    def register(self, newdata, *args):
         """
-        Register data in registry.
+        Register data in registry. Meta for each data is specified by positional
+        arguments after the new data and consists of the following:
+
+        * ``uncertainty`` - Map of corresponding uncertainties for new keys.
+          The uncertainty keys must be a subset of the new data keys.
+        * ``isconstant``: Map corresponding to new keys whose values are``True``
+          if constant or ``False`` if periodic. These keys must be a subset of
+          the new data keys.
+        * ``timeseries``: Name of corresponding time series data, ``None`` if no
+          time series. _EG_: DNI data ``timeseries`` attribute might be set to a
+          date/time data that it corresponds to. More than one data can have the
+          same ``timeseries`` data.
+        * ``data_source``: the :class:`~circus.core.data_sources.DataSource`
+          superclass that was used to acquire this data. This can be used to
+          group data from a specific source together.
 
         :param newdata: New data to add to registry. When registering new data,
             keys are not allowed to override existing keys in the data
             registry.
         :type newdata: mapping
-        :param uncertainty: Map of corresponding uncertainties for new keys.
-            The uncertainty keys must be a subset of the new data keys.
-        :type uncertainty: mapping
-        :param isconstant: Map corresponding to new keys whose values are
-            ``True`` if constant or ``False`` if periodic. These keys must be a
-            subset of the new data keys.
-        :type isconstant: mapping
-        :param timeseries: Name of corresponding time-series data, ``None`` if
-            not time-series
-        :type timeseries: dict
-        :param data_source: Name of the :class:`DataSource`.
-        :type data_source: dict
-        :raises: :exc:`~circus.core.circus_exceptions.UncertaintyPercentUnitsError`
+        :param args: uncertainty <float>, isconstant <bool>, timeseries
+            <DataSource>, data_source <DataSource>
+        :raises:
+            :exc:`~circus.core.circus_exceptions.UncertaintyPercentUnitsError`
         """
+        uncertainty, isconstant, timeseries, data_source = args
         # check uncertainty has units of percent
         if uncertainty:
             for k, v in uncertainty.iteritems():
@@ -105,63 +104,114 @@ class DataRegistry(Registry):
                                            data_source=data_source)
 
 
+class DataSourceBase(CommonBase):
+    """
+    Most general data source.
+    """
+    _path_attr = 'data_path'
+    _file_attr = 'data_file'
+
+    def __new__(mcs, name, bases, attr):
+        # use only with Calc subclasses
+        if not CommonBase.get_parents(bases, DataSourceBase):
+            return super(DataSourceBase, mcs).__new__(mcs, name, bases, attr)
+        # set param file full path if calculation path and file specified or
+        # try to set parameters from class attributes except private/magic
+        attr = mcs.set_param_file_or_parameters(attr)
+        return super(DataSourceBase, mcs).__new__(mcs, name, bases, attr)
+
+
 class DataSource(object):
     """
     Required interface for all Circus data sources such as PVSim results,
     TMY3 data and calculation input files.
 
-    :param filename: Filename of the data source.
-    :type filename: str
-    :param data_reader: A reader for this data source.
-    :type data_reader: \
-        :class:`~circus.core.data_readers.DataReader`
-    :param param_file: A JSON file that contains the a parameter map for the
-        data reader.
-    :type param_file: str
+    Each data source must specify a ``data_reader`` which must subclass
+    :class:`~circus.core.data_readers.DataReader` and that can read this data
+    source. The default is :class:`~circus.core.data_readers.JSON_Reader`.
+
+    Each data source must also specify a ``data_file`` and ``data_path`` that
+    contains the parameters required to import data from the data source using
+    the data reader. Each data reader had different parameters to specify how
+    it reads the data source, so consult the API.
+
+    This is the required interface for all source files containing data used in
+    Circus.
     """
-    def __init__(self, filename, data_reader, param_file):
+    __metaclass__ = DataSourceBase
+    #: data reader, default is :class:`~circus.core.data_readers.JSON_Reader`
+    data_reader = JSON_Reader  # can be overloaded in superclass
+
+    def __init__(self, filename):
         #: filename of file containing data
         self.filename = filename
-        #: parameter file
-        self.param_file = param_file
-        #: data reader
-        self.data_reader = data_reader
+        # check superclass for param_file created by metaclass otherwise use
+        # class attributes directly as parameters created in CommonBase
+        if hasattr(self, 'param_file'):
+            # read and load JSON parameter map file as "parameters"
+            with open(self.param_file, 'r') as fp:
+                #: dictionary of parameters for reading data source file
+                self.parameters = json.load(fp)
+        else:
+            #: parameter file
+            self.param_file = None
         # private property
         self._is_saved = True
-        # read and load JSON parameter map file as "parameters"
-        with open(param_file, 'r') as fp:
-            #: dictionary of parameters for reading data source file
-            self.parameters = json.load(fp)
-        # JSON_Reader is the default reader
         # If filename ends with ".json"
         # * JSON_Reader is original reader or data entered via UI.
         # * Different original reader, data edited, saved as JSON.
         # If file does **not** end with ".json", save data in file with ".json"
         # appended to original filename, pass original data reader as extra arg
-        if (self.filename.endswith('.json') or
-            os.path.exists(self.filename + '.json')):
+        if self._is_cached():
             # switch reader to JSON_Reader, with old reader as extra arg
-            data_reader = lambda filename, param: JSON_Reader(filename, param,
-                                                              self.data_reader)
+            proxy_data_reader = functools.partial(
+                JSON_Reader, data_reader=self.data_reader
+            )
+        else:
+            proxy_data_reader = self.data_reader
         # create the data reader object specified using parameter map
-        _data_reader = data_reader(self.filename, self.parameters)
+        data_reader_instance = proxy_data_reader(self.filename, self.parameters)
         #: data loaded from reader
-        self.data = _data_reader.load_data()
+        self.data = data_reader_instance.load_data()
         # save JSON file if doesn't exist already. JSON_Reader checks utc mod
         # time vs orig file, and deletes JSON file if orig file is newer.
-        if not (self.filename.endswith('.json') or
-                os.path.exists(self.filename + '.json')):
-            self.saveas_JSON(self.filename)  # ".json" appended by saveas_JSON
-        # NOTE: each subclass must set uncertainty and isconstant attributes,
-        # or AttributeError is raised!
-        # TODO: put uncertainty here! it is copied exactly the same in every
-        # data source
+        if not self._is_cached():
+            self.saveas_json(self.filename)  # ".json" appended by saveas_json
+        # XXX: default values of uncertainty, isconstant and timeseries are
+        # empty dictionaries.
+        #: data uncertainty in percent
+        self.uncertainty = {}
+        #: ``True`` if data is constant for all dynamic calculations
+        self.isconstant = {}
+        #: name of corresponding time series data, ``None`` if no time series
+        self.timeseries = {}
+        #: name of :class:`DataSource`
+        self.data_source = dict.fromkeys(self.data, self.__class__.__name__)
+        # TODO: need a consistent way to handle uncertainty, isconstant and time
+        # series
+        # XXX: Each superclass should do the following:
+        # * prepare the raw data from reader for the registry. Some examples of
+        #   data preparation are combining numbers and units and uncertainties,
+        #   data validation, combining years, months, days and hours into
+        #   datetime objects and parsing data from strings.
+        # * handle uncertainty, isconstant, timeseries and any other meta data.
+
+    def _is_cached(self, ex='.json'):
+        """
+        Determine if ``filename`` is cached using extension ``ex`` a string.
+
+        :param ex: extension used to cache ``filename``, default is '.json'
+        :type ex: str
+        :return: True if ``filename`` is cached using extensions ``ex``
+        :rtype: bool
+        """
+        return self.filename.endswith(ex) or os.path.exists(self.filename + ex)
 
     @property
     def issaved(self):
         return self._is_saved
 
-    def saveas_JSON(self, save_name):
+    def saveas_json(self, save_name):
         """
         Save :attr:`data`, :attr:`param_file`, original :attr:`data_reader`
         and UTC modification time as keys in JSON file. If data is edited then
@@ -195,70 +245,3 @@ class DataSource(object):
 
     def __getitem__(self, item):
         return self.data[item]
-
-
-class MetaUserDataSource(type):
-    """
-    Most general data source.
-    """
-    def __new__(cls, name, bases, attr):
-        # filter out bases from which DataSource is derived
-        bases = tuple([b for b in bases if not b in DataSource.__bases__])
-        if DataSource not in bases:
-            bases += (DataSource,)  # add DataSource to bases
-        param_file = os.path.join(attr['data_path'], attr['data_file'])
-
-        def __init__(self, filename):
-            DataSource.__init__(self, filename, attr['data_reader'],
-                                param_file)
-            #: solder joint failure uncertainty in percent
-            self.uncertainty = {}
-            #: all solder joint failure parameters are constant
-            self.isconstant = dict.fromkeys(self.data, True)
-            #: name of corresponding time-series data, ``None`` if not
-            self.timeseries = {}
-            #: name of :class:`DataSource`
-            self.data_source = dict.fromkeys(self.data,
-                                             self.__class__.__name__)
-            # TODO: refactor "isconstant" same for ever class
-            # TODO: refactor "uncertainty" to remove redundancy, several data
-            # sources use exactly the same code.
-            for sheet_params in self.parameters.itervalues():
-                for k, v in sheet_params.iteritems():
-                    try:
-                        unc_param = v['uncertainty']  # uncertainty parameters
-                    except KeyError:
-                        # skip keys without uncertainty
-                        continue  # do not raise exception if no unc key
-                    else:
-                        # uncertainty is null, use default
-                        if not unc_param:
-                            self.uncertainty[k] = DFLT_UNC
-                        elif isinstance(unc_param, basestring):
-                            # uncertainty mapped to another data field
-                            self.uncertainty[k] = self.data[unc_param]
-                            self.data.pop(unc_param)  # pop uncertainty
-                            self.isconstant.pop(unc_param)  # added in constructor
-                            self.data_source.pop(unc_param)  # added in constructor
-                        else:
-                            self.uncertainty[k] = unc_param
-
-        attr['__init__'] = __init__
-        return super(MetaUserDataSource, cls).__new__(cls, name, bases, attr)
-
-    def __init__(self, name, bases, attr):
-        super(MetaUserDataSource, self).__init__(name, bases, attr)
-
-
-class MetaDataSource(MetaUserDataSource):
-    """
-    Data source that uses :data:`_DATA` data path. Only valid for
-    :class:`~data_readers.XLRD_Reader`.
-    """
-    def __new__(cls, name, bases, attr):
-        attr['data_reader'] = XLRD_Reader
-        attr['data_path'] = _DATA
-        return super(MetaDataSource, cls).__new__(cls, name, bases, attr)
-
-# TODO: move attr/meth to base class, refactor to eliminate redundant code and
-# simplify API

--- a/circus/core/data_sources.py
+++ b/circus/core/data_sources.py
@@ -21,6 +21,7 @@ import json
 import os
 import time
 import functools
+from copy import copy
 
 DFLT_UNC = 1.0 * UREG['percent']  # default uncertainty
 
@@ -195,6 +196,21 @@ class DataSource(object):
         #   data validation, combining years, months, days and hours into
         #   datetime objects and parsing data from strings.
         # * handle uncertainty, isconstant, timeseries and any other meta data.
+        self._raw_data = copy(self.data)  # shallow copy of data
+        self.prepare_data()  # prepare data for registry
+
+    def prepare_data(self):
+        """
+        Prepare raw data from reader for the registry. Some examples of data
+        preparation are combining numbers and units and uncertainties, data
+        validation, combining years, months, days and hours into datetime
+        objects and parsing data from strings.
+
+        Each data superclass should implement this method. If there is no data
+        preparation then use ``pass``.
+        """
+        raise NotImplementedError('Data preparation not implemented. ' +
+                                  'Use ``pass`` if not required.')
 
     def _is_cached(self, ex='.json'):
         """

--- a/circus/core/data_sources.py
+++ b/circus/core/data_sources.py
@@ -197,9 +197,9 @@ class DataSource(object):
         #   datetime objects and parsing data from strings.
         # * handle uncertainty, isconstant, timeseries and any other meta data.
         self._raw_data = copy(self.data)  # shallow copy of data
-        self.prepare_data()  # prepare data for registry
+        self.__prepare_data__()  # prepare data for registry
 
-    def prepare_data(self):
+    def __prepare_data__(self):
         """
         Prepare raw data from reader for the registry. Some examples of data
         preparation are combining numbers and units and uncertainties, data

--- a/circus/core/formulas.py
+++ b/circus/core/formulas.py
@@ -165,7 +165,8 @@ class Formula(object):
     A class for formulas.
 
     Specify ``formula_importer`` which must subclass :class:`FormulaImporter`
-    to import formula source files as class.
+    to import formula source files as class. If no ``formula_importer`` is
+    specified, the default is :class:`~circus.core.formulas.PyModuleImporter`.
 
     Specify ``formula_path`` and ``formula_file`` that contains formulas in
     string form or parameters used to import the formula source file.

--- a/circus/tests/test_calcs.py
+++ b/circus/tests/test_calcs.py
@@ -36,7 +36,7 @@ def test_calc_metaclass():
             {
                 "formula": "f_rollup",
                 "args": {
-                    "data": {"freq": "months"},
+                    "data": {"freq": "MONTHLY"},
                     "outputs": {"items": "hourly_energy",
                                 "timeseries": "hourly_timeseries"}
                 },
@@ -45,7 +45,7 @@ def test_calc_metaclass():
             {
                 "formula": "f_rollup",
                 "args": {
-                    "data": {"freq": "years"},
+                    "data": {"freq": "YEARLY"},
                     "outputs": {"items": "hourly_energy",
                                 "timeseries": "hourly_timeseries"}
                 },

--- a/circus/tests/test_circus_exceptions.py
+++ b/circus/tests/test_circus_exceptions.py
@@ -1,0 +1,55 @@
+"""
+test circus exceptions
+"""
+
+from circus.core import logging
+from circus.core.circus_exceptions import (
+    UnnamedDataError, PVSimTimezoneError, DuplicateRegItemError
+)
+from nose.tools import raises, eq_
+
+LOGGER = logging.getLogger(__name__)
+
+
+@raises(UnnamedDataError)
+def test_unnamed_data_error():
+    filename = 'myfile.test'
+    try:
+        raise UnnamedDataError(filename)
+    except UnnamedDataError as err:
+        LOGGER.debug('error: %s', err.__class__)
+        eq_(err.filename, filename)
+        LOGGER.debug('filename: %s', err.filename)
+        eq_(err.message, 'Data read from "%s" without names.' % filename)
+        LOGGER.debug('message: %s', err.message)
+        raise err
+
+
+@raises(PVSimTimezoneError)
+def test_timezone_error():
+    timezone = 'US/Pacific'
+    try:
+        raise PVSimTimezoneError(timezone)
+    except PVSimTimezoneError as err:
+        LOGGER.debug('error: %s', err.__class__)
+        eq_(err.timezone, timezone)
+        LOGGER.debug('timezone: %s', err.timezone)
+        eq_(err.message, 'Incorrect timezone format: "%s".' % timezone)
+        LOGGER.debug('message: %s', err.message)
+        raise err
+
+
+@raises(DuplicateRegItemError)
+def test_duplicate_registry_item_error():
+    duplicate_keys = {'foo', 'bar'}
+    try:
+        raise DuplicateRegItemError(duplicate_keys)
+    except DuplicateRegItemError as err:
+        LOGGER.debug('error: %s', err.__class__)
+        eq_(err.duplicate_keys, duplicate_keys)
+        LOGGER.debug('duplicate_keys: %s', err.duplicate_keys)
+        eq_(err.message,
+            "Duplicate data can't be registered:\n\t%s" %
+            '\n\t'.join(duplicate_keys))
+        LOGGER.debug('message: %s', err.message)
+        raise err

--- a/circus/tests/test_data.py
+++ b/circus/tests/test_data.py
@@ -7,15 +7,94 @@ from circus.core.data_sources import DataSource
 from circus.tests import PROJ_PATH
 import os
 
+TUSCON = os.path.join(PROJ_PATH, 'data', 'Tuscon.json')
+
 
 def test_datasource_metaclasss():
 
     class DataSourceTest1(DataSource):
         data_file = 'pvpower.json'
         data_path = os.path.join(PROJ_PATH, 'data')
-        def prepare_data(self):
+
+        def __prepare_data__(self):
             pass
 
-    data_test1 = DataSourceTest1(os.path.join(PROJ_PATH, 'data', 'Tuscon.json'))
+    data_test1 = DataSourceTest1(TUSCON)
     ok_(isinstance(data_test1, DataSource))
     eq_(data_test1.param_file, os.path.join(PROJ_PATH, 'data', 'pvpower.json'))
+
+    class DataSourceTest2(DataSource):
+        latitude = {
+            "description": "latitude",
+            "units": "degrees",
+            "isconstant": True,
+            "dtype": "float"
+        }
+        longitude = {
+            "description": "longitude",
+            "units": "degrees",
+            "isconstant": True,
+            "dtype": "float"
+        }
+        elevation = {
+            "description": "altitude of site above sea level",
+            "units": "meters",
+            "isconstant": True,
+            "dtype": "float"
+        }
+        timestamp_start = {
+            "description": "initial timestamp",
+            "isconstant": True,
+            "dtype": "datetime"
+        }
+        timestamp_count = {
+            "description": "number of timesteps",
+            "isconstant": True,
+            "dtype": "int"
+        }
+        module = {
+            "description": "PV module",
+            "isconstant": True,
+            "dtype": "str"
+        }
+        inverter = {
+            "description": "PV inverter",
+            "isconstant": True,
+            "dtype": "str"
+        }
+        module_database = {
+            "description": "module databases",
+            "isconstant": True,
+            "dtype": "str"
+        }
+        inverter_database = {
+            "description": "inverter database",
+            "isconstant": True,
+            "dtype": "str"
+        }
+        Tamb = {
+            "description": "average yearly ambient air temperature",
+            "units": "degC",
+            "isconstant": True,
+            "dtype": "float"
+        }
+        Uwind = {
+            "description": "average yearly wind speed",
+            "units": "m/s",
+            "isconstant": True,
+            "dtype": "float"
+        }
+        surface_azimuth = {
+            "description": "altitude of site above sea level",
+            "units": "degrees",
+            "isconstant": True,
+            "dtype": "float"
+        }
+
+        def __prepare_data__(self):
+            pass
+
+    data_test2 = DataSourceTest2(TUSCON)
+    ok_(isinstance(data_test2, DataSource))
+    for k, v in data_test2.parameters.iteritems():
+        eq_(data_test2.parameters[k], v)

--- a/circus/tests/test_data.py
+++ b/circus/tests/test_data.py
@@ -1,0 +1,21 @@
+"""
+Test data sources
+"""
+
+from nose.tools import ok_, eq_, raises
+from circus.core.data_sources import DataSource
+from circus.tests import PROJ_PATH
+import os
+
+
+def test_datasource_metaclasss():
+
+    class DataSourceTest1(DataSource):
+        data_file = 'pvpower.json'
+        data_path = os.path.join(PROJ_PATH, 'data')
+        def prepare_data(self):
+            pass
+
+    data_test1 = DataSourceTest1(os.path.join(PROJ_PATH, 'data', 'Tuscon.json'))
+    ok_(isinstance(data_test1, DataSource))
+    eq_(data_test1.param_file, os.path.join(PROJ_PATH, 'data', 'pvpower.json'))

--- a/examples/PVPower/calculations/irradiance.json
+++ b/examples/PVPower/calculations/irradiance.json
@@ -1,6 +1,16 @@
 {
   "static": [
     {
+      "formula": "f_daterange",
+      "args": {
+        "data": {
+          "timestamp_freq": "HOURLY", "dtstart": "timestamp_start",
+          "count": "timestamp_count"
+        }
+      },
+      "returns": ["timestamps"]
+    },
+    {
       "formula": "f_clearsky",
       "args": {
         "data": {

--- a/examples/PVPower/calculations/performance.json
+++ b/examples/PVPower/calculations/performance.json
@@ -4,7 +4,7 @@
     {
       "formula": "f_aoi",
       "args": {
-        "data": {"surface_tilt": "surface_tilt", "surface_azimuth": "surface_azimuth"},
+        "data": {"surface_tilt": "latitude", "surface_azimuth": "surface_azimuth"},
         "outputs": {"solar_zenith": "solar_zenith", "solar_azimuth": "solar_azimuth"}
       },
       "returns": ["aoi"]

--- a/examples/PVPower/calculations/pvpower.json
+++ b/examples/PVPower/calculations/pvpower.json
@@ -11,7 +11,7 @@
     {
       "formula": "f_rollup",
       "args": {
-        "data": {"freq": "months"},
+        "data": {"freq": "MONTHLY"},
         "outputs": {"items": "hourly_energy", "timeseries": "hourly_timeseries"}
       },
       "returns": ["monthly_energy"]
@@ -19,7 +19,7 @@
     {
       "formula": "f_rollup",
       "args": {
-        "data": {"freq": "years"},
+        "data": {"freq": "YEARLY"},
         "outputs": {"items": "hourly_energy", "timeseries": "hourly_timeseries"}
       },
       "returns": ["annual_energy"]

--- a/examples/PVPower/data/Tuscon.json
+++ b/examples/PVPower/data/Tuscon.json
@@ -1,0 +1,15 @@
+{
+  "latitude": 30.0,
+  "longitude": -110.0,
+  "elevation": 700.0,
+  "timestamp_start": [2015, 1, 1, 0, 0, 0],
+  "timestamp_frequency": "HOURLY",
+  "timestampt_count": 8761,
+  "module_name": "Canadian_Solar_CS5P_220M___2009_",
+  "inverter_name": "ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_",
+  "module_database": "SandiaMod",
+  "inverter_database": "sandiainverter",
+  "Tamb": 20.0,
+  "Uwind": 0.0,
+  "surface_azimuth": 180.0
+}

--- a/examples/PVPower/data/Tuscon.json
+++ b/examples/PVPower/data/Tuscon.json
@@ -1,15 +1,19 @@
 {
-  "latitude": 30.0,
-  "longitude": -110.0,
-  "elevation": 700.0,
-  "timestamp_start": [2015, 1, 1, 0, 0, 0],
-  "timestamp_frequency": "HOURLY",
-  "timestampt_count": 8761,
-  "module_name": "Canadian_Solar_CS5P_220M___2009_",
-  "inverter_name": "ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_",
-  "module_database": "SandiaMod",
-  "inverter_database": "sandiainverter",
-  "Tamb": 20.0,
-  "Uwind": 0.0,
-  "surface_azimuth": 180.0
+  "data": {
+    "latitude": 30.0,
+    "longitude": -110.0,
+    "elevation": 700.0,
+    "timestamp_start": [2015, 1, 1, 0, 0, 0],
+    "timestamp_frequency": "HOURLY",
+    "timestampt_count": 8761,
+    "module_name": "Canadian_Solar_CS5P_220M___2009_",
+    "inverter_name": "ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_",
+    "module_database": "SandiaMod",
+    "inverter_database": "sandiainverter",
+    "Tamb": 20.0,
+    "Uwind": 0.0,
+    "surface_azimuth": 180.0
+  },
+  "param_file": "..\\data\\pvpower.json",
+  "data_source": "PVPowerData"
 }

--- a/examples/PVPower/data/pvpower.json
+++ b/examples/PVPower/data/pvpower.json
@@ -1,0 +1,68 @@
+{
+  "latitude": {
+    "description": "latitude",
+    "units": "degrees",
+    "isconstant": true,
+    "dtype": "float"
+  },
+  "longitude": {
+    "description": "longitude",
+    "units": "degrees",
+    "isconstant": true,
+    "dtype": "float"
+  },
+  "elevation": {
+    "description": "altitude of site above sea level",
+    "units": "meters",
+    "isconstant": true,
+    "dtype": "float"
+  },
+  "timestamp_start": {
+    "description": "initial timestamp",
+    "isconstant": true,
+    "dtype": "datetime"
+  },
+  "timestamp_count": {
+    "description": "number of timesteps",
+    "isconstant": true,
+    "dtype": "int"
+  },
+  "module": {
+    "description": "PV module",
+    "isconstant": true,
+    "dtype": "str"
+  },
+  "inverter": {
+    "description": "PV inverter",
+    "isconstant": true,
+    "dtype": "str"
+  },
+  "module_database": {
+    "description": "module databases",
+    "isconstant": true,
+    "dtype": "str"
+  },
+  "inverter_database": {
+    "description": "inverter database",
+    "isconstant": true,
+    "dtype": "str"
+  },
+  "Tamb": {
+    "description": "average yearly ambient air temperature",
+    "units": "degC",
+    "isconstant": true,
+    "dtype": "float"
+  },
+  "Uwind": {
+    "description": "average yearly wind speed",
+    "units": "m/s",
+    "isconstant": true,
+    "dtype": "float"
+  },
+  "surface_azimuth": {
+    "description": "altitude of site above sea level",
+    "units": "degrees",
+    "isconstant": true,
+    "dtype": "float"
+  }
+}

--- a/examples/PVPower/formulas/irradiance.json
+++ b/examples/PVPower/formulas/irradiance.json
@@ -1,0 +1,14 @@
+{
+  "module": "irradiance",
+  "package": null,
+  "path": null,
+  "formulas": {
+    "f_clearsky": {"islinear": true},
+    "f_solpos": {"islinear": true},
+    "f_dni_extra": {"islinear": true},
+    "f_airmass": {"islinear": true},
+    "f_pressure": {"islinear": true},
+    "f_am_abs": {"islinear": true},
+    "f_total_irrad": {"islinear": true}
+  }
+}

--- a/examples/PVPower/formulas/performance.json
+++ b/examples/PVPower/formulas/performance.json
@@ -1,0 +1,11 @@
+{
+  "module": "performance",
+  "package": null,
+  "path": null,
+  "formulas": {
+    "f_ac_power": {"islinear": true},
+    "f_dc_power": {"islinear": true},
+    "f_cell_temp": {"islinear": true},
+    "f_aoi": {"islinear": true}
+  }
+}

--- a/examples/PVPower/formulas/pvpower.json
+++ b/examples/PVPower/formulas/pvpower.json
@@ -1,10 +1,10 @@
 {
-    "module": "pvpower",
-    "package": null,
-    "path": null,
-    "formulas": {
-        "f_daterange": {"islinear": true},
-        "f_energy": {"islinear": true},
-        "f_rollup": {"islinear": true}
-    }
+  "module": "pvpower",
+  "package": null,
+  "path": null,
+  "formulas": {
+    "f_daterange": {"islinear": true},
+    "f_energy": {"islinear": true},
+    "f_rollup": {"islinear": true}
+  }
 }

--- a/examples/PVPower/models/default.json
+++ b/examples/PVPower/models/default.json
@@ -19,7 +19,14 @@
       "package": "pvpower"
     }
   },
-  "data": null, 
+  "data": {
+    "PVPowerData": {
+      "module": ".data",
+      "package": "pvpower",
+      "filename": "Tuscon.json",
+      "path":
+    }
+  },
   "calculations": {
     "PVPowerCalcs": {
       "module": ".calculations",

--- a/examples/PVPower/models/default.json
+++ b/examples/PVPower/models/default.json
@@ -1,12 +1,38 @@
 {
   "outputs": {
-    "pvpower": {
+    "PVPowerOutputs": {
       "module": ".outputs",
       "package": "pvpower"
     }
   },
-  "formulas": null, 
+  "formulas": {
+    "PVPowerFormulas": {
+      "module": ".formulas",
+      "package": "pvpower"
+    },
+    "PerformanceFormulas": {
+      "module": ".formulas",
+      "package": "pvpower"
+    },
+    "IrradianceFormulas": {
+      "module": ".formulas",
+      "package": "pvpower"
+    }
+  },
   "data": null, 
-  "calculations": null, 
+  "calculations": {
+    "PVPowerCalcs": {
+      "module": ".calculations",
+      "package": "pvpower"
+    },
+    "PerformanceCalcs": {
+      "module": ".calculations",
+      "package": "pvpower"
+    },
+    "IrradianceCalcs": {
+      "module": ".calculations",
+      "package": "pvpower"
+    }
+  },
   "simulations": null
 }

--- a/examples/PVPower/models/default.json
+++ b/examples/PVPower/models/default.json
@@ -24,7 +24,7 @@
       "module": ".data",
       "package": "pvpower",
       "filename": "Tuscon.json",
-      "path":
+      "path": "../data"
     }
   },
   "calculations": {

--- a/examples/PVPower/pvpower/__init__.py
+++ b/examples/PVPower/pvpower/__init__.py
@@ -1,5 +1,5 @@
 """
-This is the pvpower package.
+This is the PVPower Circus Demonstration Model.
 """
 
 import os

--- a/examples/PVPower/pvpower/calculations.py
+++ b/examples/PVPower/pvpower/calculations.py
@@ -6,17 +6,19 @@ from circus.core.calculations import Calc
 import os
 from pvpower import PROJ_PATH
 
+CALC_PATH = os.path.join(PROJ_PATH, 'calculations')
+
 
 class PVPowerCalcs(Calc):
-    outputs_file = 'pvpower.json'
-    outputs_path = os.path.join(PROJ_PATH, 'calculations')
+    calcs_file = 'pvpower.json'
+    calcs_path = CALC_PATH
 
 
-class PVerformanceCalcs(Calc):
-    outputs_file = 'performance.json'
-    outputs_path = os.path.join(PROJ_PATH, 'calculations')
+class PerformanceCalcs(Calc):
+    calcs_file = 'performance.json'
+    calcs_path = CALC_PATH
 
 
 class IrradianceCalcs(Calc):
-    outputs_file = 'irradiance.json'
-    outputs_path = os.path.join(PROJ_PATH, 'calculations')
+    calcs_file = 'irradiance.json'
+    calcs_path = CALC_PATH

--- a/examples/PVPower/pvpower/data.py
+++ b/examples/PVPower/pvpower/data.py
@@ -1,0 +1,44 @@
+"""
+Data sources for PV Power demo.
+"""
+
+from circus.core.data_sources import DataSource
+import os
+from pvpower import PROJ_PATH
+from datetime import datetime
+import pvlib
+
+DATA_PATH = os.path.join(PROJ_PATH, 'data')
+
+
+class PVPowerData(DataSource):
+    data_file = 'pvpower.json'
+    data_path = DATA_PATH
+
+    def prepare_data(self):
+        # set frequencies
+        for k in ('HOURLY', 'MONTHLY', 'YEARLY'):
+            self.data[k] = k
+            self.isconstant[k] = True
+        # apply metadata
+        for k, v in self.parameters:
+            # TODO: this should be applied in data reader using _meta_names from
+            # data registry which should use a meta class and all parameter
+            # files should have same layout even xlrd and numpy readers, etc.
+            if 'isconstant' in v:
+                self.isconstant[k] = v['isconstant']
+        # convert initial timestamp to datetime
+        self.data['timestamp_start'] = datetime(*self.data['timestamp_start'])
+        # get module and inverter databases
+        self.data['module_database'] = pvlib.pvsystem.retrieve_sam(
+            self.data['module_database']
+        )
+        self.data['inverter_database'] = pvlib.pvsystem.retrieve_sam(
+            self.data['inverter_database']
+        )
+        # get module and inverter
+        self.data['module'] = self.data['module_database'][self.data['module']]
+        self.data['inverter'] = (
+            self.data['inverter_database'][self.data['inverter']]
+        )
+

--- a/examples/PVPower/pvpower/data.py
+++ b/examples/PVPower/pvpower/data.py
@@ -15,7 +15,7 @@ class PVPowerData(DataSource):
     data_file = 'pvpower.json'
     data_path = DATA_PATH
 
-    def prepare_data(self):
+    def __prepare_data__(self):
         # set frequencies
         for k in ('HOURLY', 'MONTHLY', 'YEARLY'):
             self.data[k] = k

--- a/examples/PVPower/pvpower/formulas.py
+++ b/examples/PVPower/pvpower/formulas.py
@@ -1,0 +1,23 @@
+"""
+Formulas for PV Power demo
+"""
+
+from circus.core.formulas import Formula
+import os
+from pvpower import PROJ_PATH
+
+FORMULA_PATH = os.path.join(PROJ_PATH, 'formulas')
+
+class PVPowerFormulas(Formula):
+    formulas_file = 'pvpower.json'
+    formulas_path = FORMULA_PATH
+
+
+class PerformanceFormulas(Formula):
+    formulas_file = 'performance.json'
+    formulas_path = FORMULA_PATH
+
+
+class IrradianceFormulas(Formula):
+    formulas_file = 'irradiance.json'
+    formulas_path = FORMULA_PATH

--- a/examples/PVPower/tests/test_pvpower.py
+++ b/examples/PVPower/tests/test_pvpower.py
@@ -5,41 +5,39 @@ Tests for pvpower formulas
 from datetime import datetime, timedelta
 import numpy as np
 import pytz
-from time import clock
-import logging
 # XXX: add circus to python path for testing!
-from circus.core import UREG
+from circus.core import UREG, logging
 # XXX: add pvpower to python path for testing!
 from pvpower.formulas import PVPowerFormulas
 
-logging.basicConfig()
 LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(logging.DEBUG)
 PST = pytz.timezone('US/Pacific')
 FORMULAS = PVPowerFormulas()
-
-
+DTSTART = PST.localize(datetime(2007, 1, 1, 0, 0, 0))
 MONTHLY_ENERGY = [186000.0, 168000.0, 186000.0, 180000.0, 186000.0, 180000.0,
                   186000.0, 186000.0, 180000.0, 186000.0, 180000.0, 186000.0]
+
+
+def test_daterange():
+    """
+    test date range
+    """
+    dates = FORMULAS['f_daterange']('HOURLY', dtstart=DTSTART, count=12)
+    for hour in xrange(12):
+        assert dates[hour] == DTSTART + timedelta(hours=hour)
 
 
 def test_rollup():
     """
     test rollup
     """
-    dtstart = PST.localize(datetime(2007, 1, 1, 0, 0, 0))
-    dates = FORMULAS['f_daterange']('HOURLY', dtstart=dtstart, count=8761)
-    assert dates[0] == dtstart
-    assert dates[12] == dtstart + timedelta(hours=12)
+    dates = FORMULAS['f_daterange']('HOURLY', dtstart=DTSTART, count=8761)
     ac_power = 1000. * np.sin(np.arange(12) * np.pi / 12.0) ** 2
     ac_power = np.pad(ac_power, [6, 6], 'constant')
     ac_power = np.append(np.tile(ac_power, (365,)), [0]) * UREG.watt
     energy, energy_times = FORMULAS['f_energy'](ac_power, dates)
     assert energy.units == UREG.Wh
-    start = clock()
     monthly_energy = FORMULAS['f_rollup'](energy, energy_times, 'MONTHLY')
-    stop = clock()
-    LOGGER.debug('elapsed time: %g [ms]', (stop - start) * 1000.)
     assert np.allclose(monthly_energy[:12], MONTHLY_ENERGY)
     return dates, ac_power, energy, energy_times, monthly_energy
 

--- a/examples/PVPower/tests/test_pvpower.py
+++ b/examples/PVPower/tests/test_pvpower.py
@@ -1,56 +1,48 @@
 """
-tests for pvpower formulas
+Tests for pvpower formulas
 """
 
 from datetime import datetime, timedelta
 import numpy as np
 import pytz
-import imp
-import os
 from time import clock
 import logging
+# XXX: add circus to python path for testing!
 from circus.core import UREG
+# XXX: add pvpower to python path for testing!
+from pvpower.formulas import PVPowerFormulas
 
 logging.basicConfig()
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 PST = pytz.timezone('US/Pacific')
-MODNAME = 'pvpower'
-BASEDIR = os.path.dirname(__file__)
-LOGGER.debug('base dir:\n> %s', BASEDIR)
-MODPATH = os.path.abspath(os.path.join(BASEDIR, '..', 'formulas'))
-LOGGER.debug('path:\n> %s', MODPATH)
-MODFID, MODFN, MODINFO = None, None, None
+FORMULAS = PVPowerFormulas()
 
-try:
-    MODFID, MODFN, MODINFO = imp.find_module(MODNAME,[MODPATH])
-    MOD = imp.load_module(MODNAME, MODFID, MODFN, MODINFO)
-finally:
-    if MODFID:
-        MODFID.close()
 
 MONTHLY_ENERGY = [186000.0, 168000.0, 186000.0, 180000.0, 186000.0, 180000.0,
                   186000.0, 186000.0, 180000.0, 186000.0, 180000.0, 186000.0]
+
 
 def test_rollup():
     """
     test rollup
     """
     dtstart = PST.localize(datetime(2007, 1, 1, 0, 0, 0))
-    dates = MOD.f_daterange('HOURLY', dtstart=dtstart, count=8761)
+    dates = FORMULAS['f_daterange']('HOURLY', dtstart=dtstart, count=8761)
     assert dates[0] == dtstart
     assert dates[12] == dtstart + timedelta(hours=12)
-    Pac = 1000. * np.sin(np.arange(12) * np.pi / 12.0) ** 2
-    Pac = np.pad(Pac, [6, 6], 'constant')
-    Pac = np.append(np.tile(Pac, 365), 0) * UREG.watt
-    energy, energy_times = MOD.f_energy(Pac, dates)
+    ac_power = 1000. * np.sin(np.arange(12) * np.pi / 12.0) ** 2
+    ac_power = np.pad(ac_power, [6, 6], 'constant')
+    ac_power = np.append(np.tile(ac_power, (365,)), [0]) * UREG.watt
+    energy, energy_times = FORMULAS['f_energy'](ac_power, dates)
     assert energy.units == UREG.Wh
     start = clock()
-    monthly_energy = MOD.f_rollup(energy, energy_times, 'MONTHLY')
+    monthly_energy = FORMULAS['f_rollup'](energy, energy_times, 'MONTHLY')
     stop = clock()
     LOGGER.debug('elapsed time: %g [ms]', (stop - start) * 1000.)
     assert np.allclose(monthly_energy[:12], MONTHLY_ENERGY)
+    return dates, ac_power, energy, energy_times, monthly_energy
 
 
 if __name__ == "__main__":
-    test_rollup()
+    results = test_rollup()


### PR DESCRIPTION
* change `prepare_data()` method to `__prepare_data__()` so that it's not included as an parameter
* create data file for Tuscon
* add test for data source class
* fix `JSON_Reader` docstring example since missing `data`, `data_source` and `param_file` keys
* create data `param_file` for pvpower demo
* fix `apply_units` in `JSON_Reader` to work with Pint since it doesn't propagate degC units, can only create as quantity.
* define percent units as a fraction in `UREG` since Pint doesn't come with percent or fractions as part of standard unit registry
* update data source to use `CommonBase` instead of old metaclass

Note, this PR depends on #13 so please disregard those commits.
* https://github.com/mikofski/Circus/commit/e24dcd26b59effb12a8032b0377c725b8772947f - clean exceptions
* https://github.com/mikofski/Circus/commit/2eba6113ffd04b1eb0e55dfef26dabab118de76c - add `test_daterange`
* https://github.com/mikofski/Circus/commit/8d9100d3f4622ecd8cefec1ce5c320c2fc4168dc - update `test_pvpower` to use `Formula` classes
* https://github.com/mikofski/Circus/commit/80559468f62663d60bbfd07f8c059a24e17bea00 - add formula `param_files`

cc/ @SunPowerMike, @bwiktorowicz, @zdefreitas, @anomam and @ddedrick